### PR TITLE
move 6to5ify from dev-dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   },
   "homepage": "https://github.com/mapbox/react-geocoder",
   "devDependencies": {
-    "6to5ify": "^1.4.0",
     "browserify": "^6.2.0",
     "st": "^0.5.2",
     "watchify": "^2.1.0"
   },
   "dependencies": {
-    "xhr": "^1.17.0"
+    "xhr": "^1.17.0",
+    "6to5ify": "^1.4.0"
   },
   "peerDependencies": {
     "react": "0.12.x"


### PR DESCRIPTION
I think `6to5ify` needs to be a dependency and not a dev dependency.

[As seen in this simple example](http://requirebin.com/?gist=d5a805ecc141fbfd5129), if you require `react-geocoder` console it out, you get an error:

![](https://cldup.com/4NaoGgh5Fk.png) 

cc @tmcw 
