### PR TITLE
Suggest in order

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ var Geocoder = React.createClass({
   getInitialState() {
     return {
       results: [],
-      focus: null
+      focus: null,
+      searchTime: new Date()
     };
   },
   propTypes: {
@@ -88,9 +89,13 @@ var Geocoder = React.createClass({
         break;
     }
   },
-  onResult(err, res, body) {
-    if (!err && body && body.features) {
+  onResult(err, res, body, searchTime) {
+    // searchTime is compared with the last search to set the state
+    // to ensure that a slow xhr response does not scramble the
+    // sequence of autocomplete display.
+    if (!err && body && body.features && this.state.searchTime <= searchTime) {
       this.setState({
+        searchTime: searchTime,
         results: body.features,
         focus: null
       });

--- a/search.js
+++ b/search.js
@@ -1,6 +1,7 @@
 var xhr = require('xhr');
 
 function search(endpoint, source, accessToken, proximity, query, callback) {
+  var searchTime = new Date();
   var uri = endpoint + '/v4/geocode/' +
     source + '/' + encodeURIComponent(query) + '.json' +
     '?access_token=' + accessToken +
@@ -8,7 +9,9 @@ function search(endpoint, source, accessToken, proximity, query, callback) {
   xhr({
     uri: uri,
     json: true
-  }, callback);
+  }, function(err, res, body) {
+    callback(err, res, body, searchTime);
+  });
 }
 
 module.exports = search;


### PR DESCRIPTION
Adds `searchTime` state for storing when the last completed search was *started*. Prevents the following from happening:

    mai => req A
    main => req B

    req B finishes first, Geocoder displays results for `main`
    req A finishes second, Geocoder then displays results for `mai`

This check ensure that suggestions are always displayed in chronologically ascending order, rejecting responses for states that have already become obsolete.

:point_up: is this the right use of a component's `state` ?