### PR TITLE
Switch to ReactDOM.findDOMNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var React = require('react'),
+  ReactDOM = require('react-dom'),
   search = require('./search');
 
 /**
@@ -47,7 +48,7 @@ var Geocoder = React.createClass({
     focusOnMount: React.PropTypes.bool
   },
   componentDidMount() {
-    if (this.props.focusOnMount) React.findDOMNode(this.refs.input).focus();
+    if (this.props.focusOnMount) ReactDOM.findDOMNode(this.refs.input).focus();
   },
   onInput(e) {
     this.setState({loading:true});
@@ -121,7 +122,7 @@ var Geocoder = React.createClass({
     this.props.onSelect(place);
     this.setState({focus:listLocation});
     // focus on the input after click to maintain key traversal
-    React.findDOMNode(this.refs.input).focus();
+    ReactDOM.findDOMNode(this.refs.input).focus();
     return false;
   },
   render() {


### PR DESCRIPTION
It removes a warning from `React`. Maybe should add it to `package.json` as well ?

Also, you should update your babelify to `7.2.0` to fix this bug: https://github.com/babel/babelify/issues/145